### PR TITLE
[Chore] Bump version to 0.3.0

### DIFF
--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -4,7 +4,7 @@ object Version {
     const val ANDROID_MIN_SDK_VERSION = 23
     const val ANDROID_TARGET_SDK_VERSION = 32
     const val ANDROID_VERSION_CODE = 1
-    const val ANDROID_VERSION_NAME = "0.1.0"
+    const val ANDROID_VERSION_NAME = "0.3.0"
 
     // Dependencies
     const val BUILD_GRADLE_VERSION = "7.2.2"

--- a/ios/Surveys/Configurations/Plists/Info.plist
+++ b/ios/Surveys/Configurations/Plists/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/SurveysTests/Configurations/Plists/Info.plist
+++ b/ios/SurveysTests/Configurations/Plists/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/ios/SurveysUITests/Configurations/Plists/Info.plist
+++ b/ios/SurveysUITests/Configurations/Plists/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## What happened 👀

Bumped the version to 0.3.0

## Insight 📝

- Android: Manually changed in the Version.kt file
- iOS: Run ` bundle exec fastlane run increment_version_number version_number:"0.3.0"`

## Proof Of Work 📹

The CI will succeed normally
