### PR TITLE
[#25] [Android] [Integrate] As a user, I can see the home header

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -98,11 +98,15 @@ dependencies {
     implementation(Dependency.NAVIGATION_COMPOSE)
     implementation(Dependency.VIEW_MODEL_COMPOSE)
     implementation(Dependency.COIL_COMPOSE)
+    implementation(Dependency.ACCOMPANIST_PLACEHOLDER)
 
     // Koin
     implementation(Dependency.KOIN_CORE)
     implementation(Dependency.KOIN_ANDROID)
     implementation(Dependency.KOIN_COMPOSE)
+
+    // Date
+    implementation(Dependency.DATE_TIME)
 
     // Debug
     implementation(Dependency.TIMBER)

--- a/android/src/androidTest/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/androidTest/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreenTest.kt
@@ -1,24 +1,19 @@
 package co.nimblehq.ic.kmm.suv.android.ui.screens.home
 
 import androidx.activity.compose.setContent
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import co.nimblehq.ic.kmm.suv.android.MainActivity
-import co.nimblehq.ic.kmm.suv.android.R
-import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginScreen
-import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
-import co.nimblehq.ic.kmm.suv.domain.model.AppError
 import co.nimblehq.ic.kmm.suv.domain.model.User
 import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
-import co.nimblehq.ic.kmm.suv.domain.usecase.LogInUseCase
 import co.nimblehq.ic.kmm.suv.helper.date.DateTime
 import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatterImpl
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.LocalDate
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -47,9 +42,9 @@ class HomeScreenTest {
     @Test
     fun when_enter_the_home_screen__it_shows_home_header_view_components() {
         composeRule.apply {
-            onNodeWithContentDescription(HomeContentDescription.CURRENT_DATE.value).assertIsDisplayed()
-            onNodeWithContentDescription(HomeContentDescription.TODAY_TEXT.value).assertIsDisplayed()
-            onNodeWithContentDescription(HomeContentDescription.AVATAR.value).assertIsDisplayed()
+            onNodeWithContentDescription(HomeContentDescription.CURRENT_DATE).assertIsDisplayed()
+            onNodeWithContentDescription(HomeContentDescription.TODAY_TEXT).assertIsDisplayed()
+            onNodeWithContentDescription(HomeContentDescription.AVATAR).assertIsDisplayed()
         }
     }
 }

--- a/android/src/androidTest/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreenTest.kt
+++ b/android/src/androidTest/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreenTest.kt
@@ -1,0 +1,55 @@
+package co.nimblehq.ic.kmm.suv.android.ui.screens.home
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import co.nimblehq.ic.kmm.suv.android.MainActivity
+import co.nimblehq.ic.kmm.suv.android.R
+import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginScreen
+import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
+import co.nimblehq.ic.kmm.suv.domain.model.AppError
+import co.nimblehq.ic.kmm.suv.domain.model.User
+import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
+import co.nimblehq.ic.kmm.suv.domain.usecase.LogInUseCase
+import co.nimblehq.ic.kmm.suv.helper.date.DateTime
+import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatterImpl
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.LocalDate
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalTestApi
+class HomeScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    private lateinit var viewModel: HomeViewModel
+    private val mockGetProfileUseCase: GetProfileUseCase = mockk()
+    private val mockDateTime: DateTime = mockk()
+    private val user = User("email", "name", "avatarUrl")
+
+    @Before
+    fun setup() {
+        every { mockGetProfileUseCase() } returns flowOf(user)
+        every { mockDateTime.today() } returns LocalDate(2022, 11, 8)
+        viewModel = HomeViewModel(mockGetProfileUseCase, mockDateTime, DateTimeFormatterImpl())
+        composeRule.activity.setContent {
+            HomeScreen(viewModel = viewModel)
+        }
+    }
+
+    @Test
+    fun when_enter_the_home_screen__it_shows_home_header_view_components() {
+        composeRule.apply {
+            onNodeWithContentDescription(HomeContentDescription.CURRENT_DATE.value).assertIsDisplayed()
+            onNodeWithContentDescription(HomeContentDescription.TODAY_TEXT.value).assertIsDisplayed()
+            onNodeWithContentDescription(HomeContentDescription.AVATAR.value).assertIsDisplayed()
+        }
+    }
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/MainApplication.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/MainApplication.kt
@@ -2,6 +2,7 @@ package co.nimblehq.ic.kmm.suv.android
 
 import android.app.Application
 import co.nimblehq.ic.kmm.suv.android.di.loginModule
+import co.nimblehq.ic.kmm.suv.android.di.mainModule
 import co.nimblehq.ic.kmm.suv.di.initKoin
 import org.koin.android.ext.koin.androidContext
 import timber.log.Timber
@@ -12,7 +13,7 @@ class MainApplication : Application() {
         super.onCreate()
         initKoin {
             androidContext(applicationContext)
-            modules(loginModule)
+            modules(loginModule + mainModule)
         }
         setupLogging()
     }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/LoginModule.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/LoginModule.kt
@@ -1,9 +1,11 @@
 package co.nimblehq.ic.kmm.suv.android.di
 
+import co.nimblehq.ic.kmm.suv.android.ui.screens.home.HomeViewModel
 import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val loginModule = module {
     viewModel { LoginViewModel(get()) }
+    viewModel { HomeViewModel(get(), get(), get()) }
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/LoginModule.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/LoginModule.kt
@@ -1,11 +1,9 @@
 package co.nimblehq.ic.kmm.suv.android.di
 
-import co.nimblehq.ic.kmm.suv.android.ui.screens.home.HomeViewModel
 import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 
 val loginModule = module {
-    viewModel { LoginViewModel(get()) }
-    viewModel { HomeViewModel(get(), get(), get()) }
+    viewModelOf(::LoginViewModel)
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/MainModule.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/di/MainModule.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.ic.kmm.suv.android.di
+
+import co.nimblehq.ic.kmm.suv.android.ui.screens.home.HomeViewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.dsl.module
+
+val mainModule = module {
+    viewModelOf(::HomeViewModel)
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeContentDescription.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeContentDescription.kt
@@ -1,7 +1,7 @@
 package co.nimblehq.ic.kmm.suv.android.ui.screens.home
 
-enum class HomeContentDescription(val value: String) {
-    TODAY_TEXT("TODAY_TEXT"),
-    CURRENT_DATE("CURRENT_DATE"),
-    AVATAR("AVATAR"),
+object HomeContentDescription {
+    const val TODAY_TEXT = "TODAY_TEXT"
+    const val CURRENT_DATE = "CURRENT_DATE"
+    const val AVATAR = "AVATAR"
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeContentDescription.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeContentDescription.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.ic.kmm.suv.android.ui.screens.home
+
+enum class HomeContentDescription(val value: String) {
+    TODAY_TEXT("TODAY_TEXT"),
+    CURRENT_DATE("CURRENT_DATE"),
+    AVATAR("AVATAR"),
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeHeaderView.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeHeaderView.kt
@@ -41,7 +41,7 @@ fun HomeHeaderView(title: String, imageUrlString: String, isLoading: Boolean) {
                             highlightColor = Color.White,
                         ),
                     )
-                    .semantics { contentDescription = HomeContentDescription.CURRENT_DATE.value },
+                    .semantics { contentDescription = HomeContentDescription.CURRENT_DATE },
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
@@ -57,7 +57,7 @@ fun HomeHeaderView(title: String, imageUrlString: String, isLoading: Boolean) {
                             highlightColor = Color.White,
                         ),
                     )
-                    .semantics { contentDescription = HomeContentDescription.TODAY_TEXT.value }
+                    .semantics { contentDescription = HomeContentDescription.TODAY_TEXT }
             )
         }
         AsyncImage(
@@ -76,7 +76,7 @@ fun HomeHeaderView(title: String, imageUrlString: String, isLoading: Boolean) {
                     ),
                 )
                 .semantics {
-                    contentDescription = HomeContentDescription.AVATAR.value
+                    contentDescription = HomeContentDescription.AVATAR
                 }
         )
     }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeHeaderView.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeHeaderView.kt
@@ -1,0 +1,83 @@
+package co.nimblehq.ic.kmm.suv.android.ui.screens.home
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import co.nimblehq.ic.kmm.suv.android.R
+import co.nimblehq.ic.kmm.suv.android.ui.theme.Typography
+import coil.compose.AsyncImage
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.placeholder
+import com.google.accompanist.placeholder.shimmer
+
+@Composable
+fun HomeHeaderView(title: String, imageUrlString: String, isLoading: Boolean) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, top = 16.dp, end = 20.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column {
+            Text(
+                text = title,
+                color = Color.White,
+                style = Typography.caption,
+                modifier = Modifier
+                    .placeholder(
+                        visible = isLoading,
+                        color = Color.Gray,
+                        shape = RoundedCornerShape(6.5.dp),
+                        highlight = PlaceholderHighlight.shimmer(
+                            highlightColor = Color.White,
+                        ),
+                    )
+                    .semantics { contentDescription = HomeContentDescription.CURRENT_DATE.value },
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(id = R.string.home_today),
+                color = Color.White,
+                style = Typography.h4,
+                modifier = Modifier
+                    .placeholder(
+                        visible = isLoading,
+                        color = Color.Gray,
+                        shape = RoundedCornerShape(6.5.dp),
+                        highlight = PlaceholderHighlight.shimmer(
+                            highlightColor = Color.White,
+                        ),
+                    )
+                    .semantics { contentDescription = HomeContentDescription.TODAY_TEXT.value }
+            )
+        }
+        AsyncImage(
+            model = imageUrlString,
+            contentDescription = null,
+            modifier = Modifier
+                .padding(top = 19.dp)
+                .size(36.dp)
+                .clip(CircleShape)
+                .placeholder(
+                    visible = isLoading,
+                    color = Color.Gray,
+                    shape = RoundedCornerShape(4.dp),
+                    highlight = PlaceholderHighlight.shimmer(
+                        highlightColor = Color.White,
+                    ),
+                )
+                .semantics {
+                    contentDescription = HomeContentDescription.AVATAR.value
+                }
+        )
+    }
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreen.kt
@@ -2,21 +2,43 @@ package co.nimblehq.ic.kmm.suv.android.ui.screens.home
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import co.nimblehq.ic.kmm.suv.android.R
-import co.nimblehq.ic.kmm.suv.android.ui.theme.Typography
-import coil.compose.AsyncImage
+import co.nimblehq.ic.kmm.suv.android.ui.components.ErrorAlertDialog
+import org.koin.androidx.compose.getViewModel
 
 @Composable
-fun HomeScreen() {
+fun HomeScreen(viewModel: HomeViewModel = getViewModel()) {
+    val currentDate by viewModel.currentDate.collectAsState()
+    val avatarUrlString by viewModel.avatarUrlString.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadProfile()
+    }
+
+    errorMessage?.let {
+        ErrorAlertDialog(
+            message = it,
+            onButtonClick = { viewModel.dismissError() }
+        )
+    }
+
+    HomeScreenContent(currentDate, avatarUrlString, isLoading)
+}
+
+@Composable
+private fun HomeScreenContent(
+    currentDate: String,
+    imageUrlString: String,
+    isLoading: Boolean
+) {
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -25,48 +47,23 @@ fun HomeScreen() {
             .systemBarsPadding()
     ) {
         Column {
-            // TODO: Remove these dummy data later
             HomeHeaderView(
-                "FRIDAY, NOVEMBER 4",
-                "https://cdn.pixabay.com/photo/2016/11/18/23/38/child-1837375__340.png"
+                currentDate,
+                imageUrlString,
+                isLoading
             )
         }
-    }
-}
-
-@Composable
-private fun HomeHeaderView(title: String, imageUrlString: String) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, top = 16.dp, end = 20.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Column {
-            Text(
-                text = title,
-                color = Color.White,
-                style = Typography.caption
-            )
-            Text(
-                text = stringResource(id = R.string.home_today),
-                color = Color.White,
-                style = Typography.h4
-            )
-        }
-        AsyncImage(
-            model = imageUrlString,
-            contentDescription = null,
-            modifier = Modifier
-                .padding(top = 19.dp)
-                .size(36.dp)
-                .clip(CircleShape)
-        )
     }
 }
 
 @Preview
 @Composable
-fun HomeScreenPreview() {
-    HomeScreen()
+fun HomeScreenContentLoadingPreview() {
+    HomeScreenContent("TUESDAY, NOVEMBER 8", "image_url", true)
+}
+
+@Preview
+@Composable
+fun HomeScreenContentPreview() {
+    HomeScreenContent("TUESDAY, NOVEMBER 8", "image_url", false)
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreen.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeScreen.kt
@@ -26,7 +26,7 @@ fun HomeScreen(viewModel: HomeViewModel = getViewModel()) {
     errorMessage?.let {
         ErrorAlertDialog(
             message = it,
-            onButtonClick = { viewModel.dismissError() }
+            onButtonClick = viewModel::dismissError
         )
     }
 

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
@@ -6,7 +6,10 @@ import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
 import co.nimblehq.ic.kmm.suv.helper.date.DateFormat
 import co.nimblehq.ic.kmm.suv.helper.date.DateTime
 import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatter
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
 class HomeViewModel(
@@ -35,10 +38,10 @@ class HomeViewModel(
                 .catch { e ->
                     showError(e.message)
                 }
-                .onCompletion { hideLoading() }
                 .collect {
                     _avatarUrlString.value = it.avatarUrl
                 }
+            hideLoading()
         }
     }
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
@@ -1,0 +1,48 @@
+package co.nimblehq.ic.kmm.suv.android.ui.screens.home
+
+import androidx.lifecycle.viewModelScope
+import co.nimblehq.ic.kmm.suv.android.ui.base.BaseViewModel
+import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
+import co.nimblehq.ic.kmm.suv.helper.date.DateFormat
+import co.nimblehq.ic.kmm.suv.helper.date.DateTime
+import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+class HomeViewModel(
+    private val getProfileUseCase: GetProfileUseCase,
+    dateTime: DateTime,
+    dateTimeFormatter: DateTimeFormatter
+    ) : BaseViewModel() {
+
+    private val _currentDate = MutableStateFlow("")
+    val currentDate: StateFlow<String> = _currentDate.asStateFlow()
+
+    private val _avatarUrlString = MutableStateFlow("")
+    val avatarUrlString: StateFlow<String> = _avatarUrlString.asStateFlow()
+
+    init {
+        _currentDate.value = dateTimeFormatter.getFormattedString(
+            dateTime.today(),
+            DateFormat.WeekDayMonthDay
+        ).uppercase()
+    }
+
+    fun loadProfile() {
+        showLoading()
+        viewModelScope.launch {
+            getProfileUseCase()
+                .catch { e ->
+                    hideLoading()
+                    showError(e.message)
+                }
+                .collect {
+                    hideLoading()
+                    _avatarUrlString.value = it.avatarUrl
+                }
+        }
+    }
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModel.kt
@@ -6,17 +6,14 @@ import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
 import co.nimblehq.ic.kmm.suv.helper.date.DateFormat
 import co.nimblehq.ic.kmm.suv.helper.date.DateTime
 import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatter
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val getProfileUseCase: GetProfileUseCase,
     dateTime: DateTime,
     dateTimeFormatter: DateTimeFormatter
-    ) : BaseViewModel() {
+) : BaseViewModel() {
 
     private val _currentDate = MutableStateFlow("")
     val currentDate: StateFlow<String> = _currentDate.asStateFlow()
@@ -36,11 +33,10 @@ class HomeViewModel(
         viewModelScope.launch {
             getProfileUseCase()
                 .catch { e ->
-                    hideLoading()
                     showError(e.message)
                 }
+                .onCompletion { hideLoading() }
                 .collect {
-                    hideLoading()
                     _avatarUrlString.value = it.avatarUrl
                 }
         }

--- a/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModelTest.kt
@@ -1,0 +1,80 @@
+package co.nimblehq.ic.kmm.suv.android.ui.screens.home
+
+import androidx.activity.compose.setContent
+import co.nimblehq.ic.kmm.suv.android.rule.MainCoroutinesRule
+import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
+import co.nimblehq.ic.kmm.suv.domain.model.AppError
+import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
+import co.nimblehq.ic.kmm.suv.domain.usecase.LogInUseCase
+import co.nimblehq.ic.kmm.suv.helper.date.DateTime
+import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatter
+import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatterImpl
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.LocalDate
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class HomeViewModelTest {
+
+    private lateinit var viewModel: HomeViewModel
+
+    private val mockGetProfileUseCase: GetProfileUseCase = mockk()
+    private val mockDateTime: DateTime = mockk()
+
+    @ExperimentalCoroutinesApi
+    @get:Rule
+    val mainCoroutinesRule = MainCoroutinesRule()
+
+    @Before
+    fun setup() {
+        every { mockDateTime.today() } returns LocalDate(2022, 11, 8)
+        every { mockGetProfileUseCase() } returns flowOf(mockk())
+        viewModel = HomeViewModel(mockGetProfileUseCase, mockDateTime, DateTimeFormatterImpl())
+    }
+
+    @Test
+    fun `When its init, today should be right`() {
+        viewModel.currentDate.value shouldBe "TUESDAY, NOVEMBER 8"
+    }
+
+    @Test
+    fun `When load profile successfully, the avatar url should not be null`() = runTest {
+        viewModel.loadProfile()
+        advanceUntilIdle()
+
+        viewModel.avatarUrlString.value shouldNotBe null
+    }
+
+    @Test
+    fun `When load profile failed, error message should not be null`() = runTest {
+        val expectedError = AppError("Load profile failed!")
+        every { mockGetProfileUseCase() } returns flow { throw expectedError }
+        viewModel.loadProfile()
+        advanceUntilIdle()
+
+        viewModel.errorMessage.value shouldBe expectedError.message
+    }
+
+    @Test
+    fun `When load profile, isLoading should change from false to true`() = runTest {
+        Dispatchers.setMain(StandardTestDispatcher())
+        viewModel.loadProfile()
+
+        viewModel.isLoading.value shouldBe true
+        advanceUntilIdle()
+        viewModel.isLoading.value shouldBe false
+    }
+}

--- a/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModelTest.kt
+++ b/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/home/HomeViewModelTest.kt
@@ -1,16 +1,12 @@
 package co.nimblehq.ic.kmm.suv.android.ui.screens.home
 
-import androidx.activity.compose.setContent
 import co.nimblehq.ic.kmm.suv.android.rule.MainCoroutinesRule
-import co.nimblehq.ic.kmm.suv.android.ui.screens.login.LoginViewModel
 import co.nimblehq.ic.kmm.suv.domain.model.AppError
+import co.nimblehq.ic.kmm.suv.domain.model.User
 import co.nimblehq.ic.kmm.suv.domain.usecase.GetProfileUseCase
-import co.nimblehq.ic.kmm.suv.domain.usecase.LogInUseCase
 import co.nimblehq.ic.kmm.suv.helper.date.DateTime
-import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatter
 import co.nimblehq.ic.kmm.suv.helper.date.DateTimeFormatterImpl
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +29,7 @@ class HomeViewModelTest {
 
     private val mockGetProfileUseCase: GetProfileUseCase = mockk()
     private val mockDateTime: DateTime = mockk()
+    private val mockUser = User("email", "name", "avatarUrl")
 
     @ExperimentalCoroutinesApi
     @get:Rule
@@ -41,7 +38,7 @@ class HomeViewModelTest {
     @Before
     fun setup() {
         every { mockDateTime.today() } returns LocalDate(2022, 11, 8)
-        every { mockGetProfileUseCase() } returns flowOf(mockk())
+        every { mockGetProfileUseCase() } returns flowOf(mockUser)
         viewModel = HomeViewModel(mockGetProfileUseCase, mockDateTime, DateTimeFormatterImpl())
     }
 
@@ -55,7 +52,7 @@ class HomeViewModelTest {
         viewModel.loadProfile()
         advanceUntilIdle()
 
-        viewModel.avatarUrlString.value shouldNotBe null
+        viewModel.avatarUrlString.value shouldBe mockUser.avatarUrl
     }
 
     @Test

--- a/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/login/LoginViewModelTest.kt
+++ b/android/src/test/java/co/nimblehq/ic/kmm/suv/android/ui/screens/login/LoginViewModelTest.kt
@@ -62,7 +62,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `When update email, the uiState's email should be changed`() = runTest {
+    fun `When update email, the email should be changed`() = runTest {
         val expectedEmail = "new@nimblehq.co"
         loginViewModel = LoginViewModel(mockLogInUseCase)
         loginViewModel.updateEmail(expectedEmail)
@@ -71,7 +71,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `When update password, the uiState's password should be changed`() = runTest {
+    fun `When update password, the password should be changed`() = runTest {
         val expectedPassword = "newPassword"
         loginViewModel = LoginViewModel(mockLogInUseCase)
         loginViewModel.updatePassword(expectedPassword)
@@ -80,7 +80,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `When the error alert is shown, the uiState's errorMessage should be null`() = runTest {
+    fun `When the error alert is shown, the errorMessage should be null`() = runTest {
         loginViewModel = LoginViewModel(mockLogInUseCase)
         loginViewModel.dismissError()
 

--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -16,7 +16,7 @@ object Dependency {
     const val NAVIGATION_COMPOSE = "androidx.navigation:navigation-compose:${Version.NAVIGATION_COMPOSE}"
     const val VIEW_MODEL_COMPOSE = "androidx.lifecycle:lifecycle-viewmodel-compose:${Version.VIEW_MODEL_COMPOSE}"
     const val COIL_COMPOSE = "io.coil-kt:coil-compose:${Version.COIL_COMPOSE}"
-
+    const val ACCOMPANIST_PLACEHOLDER = "com.google.accompanist:accompanist-placeholder:${Version.ACCOMPANIST}"
 
     // Kotlinx
     const val COROUTINES_CORE = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Version.COROUTINES_CORE}"

--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -25,6 +25,7 @@ object Version {
     const val NAVIGATION_COMPOSE = "2.5.1"
     const val VIEW_MODEL_COMPOSE = "2.5.1"
     const val COIL_COMPOSE = "2.2.2"
+    const val ACCOMPANIST = "0.25.1"
 
     const val KOIN = "3.2.0"
     const val KOIN_ANDROID = "3.3.0"


### PR DESCRIPTION
- Resolves #25 

## What happened 👀

- Added integrate implementation for the home header on the Android side (get current date and profile data)

## Insight 📝

- I added [placeholder](https://github.com/google/accompanist/tree/main/placeholder) library to support the loading indicator on the home screen.
- I also added unit tests and UI tests for the home screen.

TIL: Use `Modifier.semantics { contentDescription = "..." }` to access the UI component from UI Tests

## Proof Of Work 📹

https://user-images.githubusercontent.com/19943832/200487400-01ec5019-a0f4-4ad0-b001-552d2ce2d5ab.mov
