### PR TITLE
[#54] [#56] [Android] [UI] As a user, I can see nps answer

### DIFF
--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
@@ -1,0 +1,96 @@
+package co.nimblehq.ic.kmm.suv.android.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import co.nimblehq.ic.kmm.suv.android.R
+import co.nimblehq.ic.kmm.suv.android.ui.theme.Typography
+
+@Composable
+fun NpsAnswer(
+    currentIndex: Int = -1,
+    onIndexChange: (Int) -> Unit,
+) {
+    var selectedIndex by remember { mutableStateOf(currentIndex) }
+    val npsSize = 10
+    val npsHeight = 56.dp
+    val npsWidth = 345.5.dp
+    Column {
+        Row(
+            modifier = Modifier
+                .border(BorderStroke(0.5.dp, Color.White), RoundedCornerShape(10.dp))
+        ) {
+            (0 until npsSize).forEach { index ->
+                val isHighlight = index <= selectedIndex
+                val alpha = if (isHighlight) 1f else 0.5f
+                Button(
+                    onClick = {
+                        selectedIndex = index
+                        onIndexChange(index)
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = Color.Transparent
+                    ),
+                    elevation = null,
+                    contentPadding = PaddingValues(0.dp),
+                    modifier = Modifier
+                        .alpha(alpha)
+                        .width(34.dp)
+                        .height(npsHeight)
+                ) {
+                    Text(
+                        text = "${index + 1}",
+                        color = Color.White,
+                        style = if (isHighlight) Typography.h6 else Typography.h6.copy(fontWeight = FontWeight.Normal)
+                    )
+                }
+                if (index != npsSize - 1) {
+                    Spacer(
+                        modifier = Modifier
+                            .width(0.5.dp)
+                            .height(npsHeight)
+                            .background(Color.White)
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.width(npsWidth)
+        ) {
+            val leftRangeAlpha = if (selectedIndex < 5) 1f else 0.5f
+            Text(
+                text = stringResource(id = R.string.nps_not_at_all_likely),
+                color = Color.White,
+                style = Typography.subtitle2,
+                modifier = Modifier.alpha(leftRangeAlpha)
+            )
+            Text(
+                text = stringResource(id = R.string.nps_extremely_likely),
+                color = Color.White,
+                style = Typography.subtitle2,
+                modifier = Modifier.alpha(1.5f - leftRangeAlpha)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NpsAnswerPreview() {
+    NpsAnswer(onIndexChange = {})
+}

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
@@ -33,7 +33,7 @@ fun NpsAnswer(
             modifier = Modifier
                 .border(BorderStroke(0.5.dp, Color.White), RoundedCornerShape(10.dp))
         ) {
-            (0 until npsSize).forEach { index ->
+            for (index in 0 until npsSize) {
                 val isHighlight = index <= selectedIndex
                 val alpha = if (isHighlight) 1f else 0.5f
                 Button(

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/components/NpsAnswer.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
@@ -17,7 +16,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.nimblehq.ic.kmm.suv.android.R
+import co.nimblehq.ic.kmm.suv.android.ui.theme.AppTheme
 import co.nimblehq.ic.kmm.suv.android.ui.theme.Typography
+
+private const val NPS_SIZE = 10
+private val NPS_VIEW_HEIGHT = 56.dp
+private val NPS_VIEW_WIDTH = 345.5.dp
 
 @Composable
 fun NpsAnswer(
@@ -25,15 +29,12 @@ fun NpsAnswer(
     onIndexChange: (Int) -> Unit,
 ) {
     var selectedIndex by remember { mutableStateOf(currentIndex) }
-    val npsSize = 10
-    val npsHeight = 56.dp
-    val npsWidth = 345.5.dp
     Column {
         Row(
             modifier = Modifier
-                .border(BorderStroke(0.5.dp, Color.White), RoundedCornerShape(10.dp))
+                .border(BorderStroke(0.5.dp, Color.White), AppTheme.shapes.medium)
         ) {
-            for (index in 0 until npsSize) {
+            for (index in 0 until NPS_SIZE) {
                 val isHighlight = index <= selectedIndex
                 val alpha = if (isHighlight) 1f else 0.5f
                 Button(
@@ -49,7 +50,7 @@ fun NpsAnswer(
                     modifier = Modifier
                         .alpha(alpha)
                         .width(34.dp)
-                        .height(npsHeight)
+                        .height(NPS_VIEW_HEIGHT)
                 ) {
                     Text(
                         text = "${index + 1}",
@@ -57,11 +58,11 @@ fun NpsAnswer(
                         style = if (isHighlight) Typography.h6 else Typography.h6.copy(fontWeight = FontWeight.Normal)
                     )
                 }
-                if (index != npsSize - 1) {
+                if (index != NPS_SIZE - 1) {
                     Spacer(
                         modifier = Modifier
                             .width(0.5.dp)
-                            .height(npsHeight)
+                            .height(NPS_VIEW_HEIGHT)
                             .background(Color.White)
                     )
                 }
@@ -70,7 +71,7 @@ fun NpsAnswer(
         Spacer(modifier = Modifier.height(16.dp))
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.width(npsWidth)
+            modifier = Modifier.width(NPS_VIEW_WIDTH)
         ) {
             val leftRangeAlpha = if (selectedIndex < 5) 1f else 0.5f
             Text(

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/surveyquestions/SurveyQuestionsScreen.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/screens/surveyquestions/SurveyQuestionsScreen.kt
@@ -254,6 +254,7 @@ private fun Answer(type: QuestionDisplayType, onAnswerClick: (Int) -> Unit) {
             onIndexChange = onAnswerClick,
             highlightStyle = EmojiHighlightStyle.ONE
         )
+        QuestionDisplayType.NPS -> NpsAnswer(onIndexChange = onAnswerClick)
         else -> Text(text = type.value) // TODO: Remove this later
     }
 }

--- a/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/theme/Type.kt
+++ b/android/src/main/java/co/nimblehq/ic/kmm/suv/android/ui/theme/Type.kt
@@ -24,6 +24,10 @@ val Typography = Typography(
         fontWeight = FontWeight.Bold,
         fontSize = 28.sp
     ),
+    h6 = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = 20.sp
+    ),
     subtitle1 = TextStyle(
         fontWeight = FontWeight.Normal,
         fontSize = 17.sp

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
 
     <string name="start_survey">Start Survey</string>
     <string name="submit_button">Submit</string>
+    <string name="nps_not_at_all_likely">Not at all Likely</string>
+    <string name="nps_extremely_likely">Extremely Likely</string>
 </resources>


### PR DESCRIPTION
- Close #54
- Close #56

## What happened 👀

I added the NPS answer view for the survey questions screen.

## Insight 📝

Just created `NpsAnswer` with Jetpack Compose.

TIL: Modifier with border and rounded style `Modifier.border(BorderStroke(0.5.dp, Color.White), RoundedCornerShape(10.dp))`

## Proof Of Work 📹

https://user-images.githubusercontent.com/19943832/206978945-262b522e-f579-4623-85b0-e7ca1d73ce98.mov

