### PR TITLE
[Bug] Fix: CD workflow for production build

### DIFF
--- a/.github/workflows/deploy_ios_production_build.yml
+++ b/.github/workflows/deploy_ios_production_build.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - bug/deploy-production-ios-build
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/deploy_ios_production_build.yml
+++ b/.github/workflows/deploy_ios_production_build.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - bug/deploy-production-ios-build
   workflow_dispatch:
 
 defaults:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -174,8 +174,7 @@ platform :ios do
     builder.build_app_store(
       Constants.SCHEME_NAME_PRODUCTION,
       Constants.PRODUCT_NAME_PRODUCTION,
-      Constants.BUNDLE_ID_PRODUCTION,
-      true
+      Constants.BUNDLE_ID_PRODUCTION
     )
     set_connect_api_key
     upload_build_to_appstore

--- a/ios/fastlane/Managers/BuildManager.rb
+++ b/ios/fastlane/Managers/BuildManager.rb
@@ -20,16 +20,16 @@ class BuildManager
     )
   end
 
-  def build_app_store(scheme, product_name, bundle_identifier, include_bitcode)
+  def build_app_store(scheme, product_name, bundle_identifier)
     @fastlane.gym(
       scheme: scheme,
       export_method: 'app-store',
       export_options: {
         provisioningProfiles: {
-          @bundle_identifier_staging.to_s => "match AppStore #{bundle_identifier}"
+          @bundle_identifier.to_s => "match AppStore #{bundle_identifier}"
         }
       },
-      include_bitcode: include_bitcode,
+      include_bitcode: false,
       output_name: product_name
     )
   end


### PR DESCRIPTION
## What happened 👀

There are bugs on the CD workflow for uploading production iOS builds to App Store Connect:
1. Having bitcode mode
2. Wrong bundle identifier (bug from iOS templates).

## Insight 📝

First, I disable bitcode mode as it's not supported by Xcode 14. Second, I fixed the wrong bundle identifier

## Proof Of Work 📹

<img width="554" alt="Screenshot 2023-01-31 at 14 55 57" src="https://user-images.githubusercontent.com/19943832/215700245-778b5703-9e92-4396-95ba-de841e354651.png">

